### PR TITLE
Feature/#20202 alarms include query data in notify to incident

### DIFF
--- a/resources/templates/default/rsyslog_07-alarms.conf.erb
+++ b/resources/templates/default/rsyslog_07-alarms.conf.erb
@@ -27,13 +27,11 @@ template(name="alarm-triggered" type="list") {
       constant(value="\",\"alarm_name\":\"")             property(name="$!rfc5424-sd!alarm-event@39483!alarm-name" format="json")
       constant(value="\",\"alarm_product_type\":\"")     property(name="$!rfc5424-sd!alarm-event@39483!alarm-product-type" format="json")
       constant(value="\",\"alarm_condition\":\"")        property(name="$!rfc5424-sd!alarm-event@39483!alarm-condition" format="json")
-<<<<<<< HEAD
       constant(value="\",\"traffic_wan_ip\":\"")         property(name="$!rfc5424-sd!alarm-event@39483!traffic-wan-ip" format="json")
       constant(value="\",\"traffic_lan_ip\":\"")         property(name="$!rfc5424-sd!alarm-event@39483!traffic-lan-ip" format="json")
       constant(value="\",\"intrusion_source\":\"")       property(name="$!rfc5424-sd!alarm-event@39483!intrusion-source" format="json")
       constant(value="\",\"intrusion_target\":\"")        property(name="$!rfc5424-sd!alarm-event@39483!intrusion-target" format="json")
       constant(value="\",\"wireless_station\":\"")        property(name="$!rfc5424-sd!alarm-event@39483!wireless-station" format="json")
-=======
       constant(value="\",\"service_provider\":\"")       property(name="$!rfc5424-sd!alarm-event@39483!service_provider" format="json")
       constant(value="\",\"service_provider_uuid\":\"")  property(name="$!rfc5424-sd!alarm-event@39483!service_provider-uuid" format="json")
       constant(value="\",\"deployment\":\"")             property(name="$!rfc5424-sd!alarm-event@39483!deployment" format="json")
@@ -50,7 +48,6 @@ template(name="alarm-triggered" type="list") {
       constant(value="\",\"building_uuid\":\"")          property(name="$!rfc5424-sd!alarm-event@39483!building-uuid" format="json")
       constant(value="\",\"floor\":\"")                  property(name="$!rfc5424-sd!alarm-event@39483!floor" format="json")
       constant(value="\",\"floor_uuid\":\"")             property(name="$!rfc5424-sd!alarm-event@39483!floor-uuid" format="json")
->>>>>>> master
     constant(value="\"}")
 }
 


### PR DESCRIPTION
### Update rsyslog_07-alarms.conf.erb to include new alarm event fields

Added new fields to `rsyslog_07-alarms.conf.erb` for improved logging of alarm events:  
`traffic_wan_ip`, `traffic_lan_ip`, `intrusion_source`, `intrusion_target`, and `wireless_station`